### PR TITLE
Make the code compatible with new dependency injection component

### DIFF
--- a/src/Bex/Behat/Magento2Extension/HelperContainer/DelegatingSymfonyServiceContainer.php
+++ b/src/Bex/Behat/Magento2Extension/HelperContainer/DelegatingSymfonyServiceContainer.php
@@ -72,12 +72,12 @@ class DelegatingSymfonyServiceContainer extends SymfonyServiceContainer implemen
         throw new ServiceNotFoundException($id);
     }
 
-    public function compile()
+    public function compile(bool $resolveEnvPlaceholders = false)
     {
         foreach ($this->fallbackContainers as $serviceContainer) {
             $this->parameterBag->add($serviceContainer->getParameterBag()->all());
         }
 
-        parent::compile();
+        parent::compile($resolveEnvPlaceholders);
     }
 }


### PR DESCRIPTION
The package **symfony/dependency-injection** >= **4.0** introduced a new argument to the `\Symfony\Component\DependencyInjection\ContainerBuilder::compile()` method and because it's being extended by the module, PHP reports a warning about incompatible declaration.

This commit fixes that by adding the optional argument, making it backward compatible.